### PR TITLE
fix: video page displays not only chat section on smaller screen

### DIFF
--- a/src/app/shared/[slug]/page.tsx
+++ b/src/app/shared/[slug]/page.tsx
@@ -61,7 +61,7 @@ export default async function SharedVideoPage({ params }: SharedVideoPageProps) 
   return (
     <main className="flex flex-col min-h-screen bg-melody-gradient relative">
       <div className="relative z-10">
-        <div className="grid grid-cols-1 lg:grid-cols-7 h-screen">
+        <div className="grid grid-cols-1 lg:grid-cols-7 min-h-screen">
           <div className="lg:col-span-4 h-full overflow-y-auto scrollbar-none relative">
             <div className="sticky top-0 z-50 bg-white dark:bg-black border-b">
               <div className="flex items-center p-4 gap-2">


### PR DESCRIPTION
This PR fixes a UI bug on the video page that only displays the chat section on a smaller screen

Before fix:
<img width="1363" height="870" alt="image" src="https://github.com/user-attachments/assets/6c93771a-f09e-4844-9b3f-b7cd4bd5cbbd" />

<img width="583" height="827" alt="image" src="https://github.com/user-attachments/assets/2d175113-ce9a-491a-8fc7-36d972f9204f" />

After fix:
<img width="1608" height="3018" alt="image" src="https://github.com/user-attachments/assets/c4356007-693c-4523-952a-a00d6cb8b1f4" />

<img width="532" height="4375" alt="image" src="https://github.com/user-attachments/assets/840e342a-c05c-4916-a320-326a2d57c064" />
