### PR TITLE
Make theme selector full width

### DIFF
--- a/src/app/profile/user-preferences.tsx
+++ b/src/app/profile/user-preferences.tsx
@@ -65,7 +65,7 @@ export function UserPreferences({ defaultLanguage }: UserPreferencesProps) {
           <div>
             <h4 className="text-sm md:text-base mb-3">{t('selectTheme')}</h4>
             <Select value={theme} onValueChange={handleThemeChange}>
-              <SelectTrigger className="w-full sm:w-[200px]">
+              <SelectTrigger className="w-full">
                 <SelectValue placeholder={t('selectThemePlaceholder')} />
               </SelectTrigger>
               <SelectContent>


### PR DESCRIPTION
## Summary
- Removed responsive width constraint from theme selector in user preferences
- Changed from `w-full sm:w-[200px]` to `w-full` for consistent full-width display

## Test plan
- [ ] Navigate to user profile/preferences page
- [ ] Verify theme selector takes full width on all screen sizes
- [ ] Test theme switching functionality still works correctly

🤖 Generated with [Claude Code](https://claude.ai/code)